### PR TITLE
Collision checking

### DIFF
--- a/descartes_core/CMakeLists.txt
+++ b/descartes_core/CMakeLists.txt
@@ -7,6 +7,7 @@ find_package(catkin REQUIRED COMPONENTS
   cmake_modules
   moveit_core
   roscpp
+  moveit_msgs
 )
 
 find_package(Boost REQUIRED)

--- a/descartes_core/include/descartes_core/robot_model.h
+++ b/descartes_core/include/descartes_core/robot_model.h
@@ -22,6 +22,7 @@
 // TODO: The include below picks up Eigen::Affine3d, but there is probably a better way
 #include <moveit/kinematic_constraints/kinematic_constraint.h>
 #include "descartes_core/utils.h"
+#include <moveit_msgs/PlanningScene.h>
 
 namespace descartes_core
 {
@@ -144,6 +145,10 @@ public:
 
   virtual bool isValidMove(const double* s, const double* f, double dt) const = 0;
 
+  virtual bool updatePlanningScene(const moveit_msgs::PlanningScene &scene){}
+
+  virtual moveit::core::RobotStatePtr getState(){};
+  
 protected:
   RobotModel() : check_collisions_(false)
   {

--- a/descartes_core/include/descartes_core/robot_model.h
+++ b/descartes_core/include/descartes_core/robot_model.h
@@ -147,8 +147,6 @@ public:
 
   virtual bool updatePlanningScene(const moveit_msgs::PlanningScene &scene){}
 
-  virtual moveit::core::RobotStatePtr getState(){};
-  
 protected:
   RobotModel() : check_collisions_(false)
   {

--- a/descartes_core/include/descartes_core/robot_model.h
+++ b/descartes_core/include/descartes_core/robot_model.h
@@ -116,7 +116,7 @@ public:
    */
   virtual void setCheckCollisions(bool check_collisions)
   {
-    ROS_INFO("Collision checking enabled");
+    ROS_INFO_STREAM("Check collisions set to "<<check_collisions);
     check_collisions_ = check_collisions;
   }
 
@@ -146,7 +146,10 @@ public:
 
   virtual bool isValidMove(const double* s, const double* f, double dt) const = 0;
 
-  virtual bool updatePlanningScene(const moveit_msgs::PlanningScene &scene){}
+  virtual bool updatePlanningScene(const moveit_msgs::PlanningScene &scene){
+    ROS_ERROR("updatePlanningScene() method not implemented");
+    return false;
+  }
 
 protected:
   RobotModel() : check_collisions_(false)

--- a/descartes_core/include/descartes_core/robot_model.h
+++ b/descartes_core/include/descartes_core/robot_model.h
@@ -116,6 +116,7 @@ public:
    */
   virtual void setCheckCollisions(bool check_collisions)
   {
+    ROS_INFO("Collision checking enabled");
     check_collisions_ = check_collisions;
   }
 

--- a/descartes_core/package.xml
+++ b/descartes_core/package.xml
@@ -20,10 +20,12 @@
   <build_depend>roscpp</build_depend>
   <build_depend>cmake_modules</build_depend>
   <build_depend>eigen</build_depend>
+  <build_depend>moveit_msgs</build_depend>
 
   <run_depend>boost</run_depend>
   <run_depend>moveit_core</run_depend>
   <run_depend>roscpp</run_depend>
+  <run_depend>moveit_msgs</run_depend>
 
   <test_depend>rosunit</test_depend>
 

--- a/descartes_moveit/CMakeLists.txt
+++ b/descartes_moveit/CMakeLists.txt
@@ -36,6 +36,7 @@ catkin_package(
     rosconsole_bridge
     tf
     peanut_kinematics
+    moveit_msgs
   DEPENDS
     Boost
     EIGEN3

--- a/descartes_moveit/include/descartes_moveit/jaco3_moveit_state_adapter.h
+++ b/descartes_moveit/include/descartes_moveit/jaco3_moveit_state_adapter.h
@@ -65,7 +65,7 @@ protected:
   collision_detection::AllowedCollisionMatrix acm_;
   collision_detection::CollisionRequest collision_request_;
   std::string octomap_name_ = "<octomap>";
-  std::vector<std::string> check_collision_links_ = {"shoulder_link", "half_arm_1_link", "half_arm_2_link", "forearm_link", "end_effector_link"};
+  std::vector<std::string> check_collision_links_ = {"forearm_link", "half_arm_1_link", "spherical_wrist_2_link"};
 
 };
 

--- a/descartes_moveit/include/descartes_moveit/jaco3_moveit_state_adapter.h
+++ b/descartes_moveit/include/descartes_moveit/jaco3_moveit_state_adapter.h
@@ -63,6 +63,9 @@ protected:
   descartes_core::Frame world_to_base_;
 
   collision_detection::AllowedCollisionMatrix acm_;
+  collision_detection::CollisionRequest collision_request_;
+  std::string octomap_name_ = "<octomap>";
+  std::vector<std::string> check_collision_links_ = {"shoulder_link", "half_arm_1_link", "half_arm_2_link", "forearm_link", "end_effector_link"};
 
 };
 

--- a/descartes_moveit/include/descartes_moveit/jaco3_moveit_state_adapter.h
+++ b/descartes_moveit/include/descartes_moveit/jaco3_moveit_state_adapter.h
@@ -7,7 +7,6 @@
 
 #include "descartes_moveit/moveit_state_adapter.h"
 #include <peanut_kinematics/jaco3_ik.h>
-#include <moveit_msgs/GetPlanningScene.h>
 #include <moveit_msgs/PlanningScene.h>
 
 namespace descartes_moveit

--- a/descartes_moveit/include/descartes_moveit/jaco3_moveit_state_adapter.h
+++ b/descartes_moveit/include/descartes_moveit/jaco3_moveit_state_adapter.h
@@ -61,6 +61,9 @@ protected:
    * of the IKFast solver and the base of the MoveIt move group.
    */
   descartes_core::Frame world_to_base_;
+
+  collision_detection::AllowedCollisionMatrix acm_;
+
 };
 
 }  // end namespace 'descartes_moveit'

--- a/descartes_moveit/include/descartes_moveit/jaco3_moveit_state_adapter.h
+++ b/descartes_moveit/include/descartes_moveit/jaco3_moveit_state_adapter.h
@@ -64,8 +64,8 @@ protected:
   collision_detection::AllowedCollisionMatrix acm_;
   collision_detection::CollisionRequest collision_request_;
   std::string octomap_link_ = "<octomap>";
-  std::vector<std::string> collision_arm_links_ = {"forearm_link", "half_arm_1_link", "spherical_wrist_2_link"};
-  std::vector<std::string> collision_robot_links_ = {"tower_link", "arm_base_cover", "camera_box", "mobile_base_link"};
+  std::vector<std::string> collision_arm_links_ = {"half_arm_2_link", "forearm_link"};
+  std::vector<std::string> collision_robot_links_ = {"tower_link", "camera_box"};
 };
 
 }  // end namespace 'descartes_moveit'

--- a/descartes_moveit/include/descartes_moveit/jaco3_moveit_state_adapter.h
+++ b/descartes_moveit/include/descartes_moveit/jaco3_moveit_state_adapter.h
@@ -36,14 +36,6 @@ public:
   virtual bool updatePlanningScene(const moveit_msgs::PlanningScene &scene);
 
   /**
-   * @brief Returns the underlying moveit state object so it can be used to generate seeds
-   */
-  moveit::core::RobotStatePtr getState()
-  {
-    return robot_state_;
-  }
-
-  /**
    * @brief Sets the internal state of the robot model to the argument. For the IKFast impl,
    * it also recomputes the transformations to/from the IKFast reference frames.
    */

--- a/descartes_moveit/include/descartes_moveit/jaco3_moveit_state_adapter.h
+++ b/descartes_moveit/include/descartes_moveit/jaco3_moveit_state_adapter.h
@@ -7,6 +7,8 @@
 
 #include "descartes_moveit/moveit_state_adapter.h"
 #include <peanut_kinematics/jaco3_ik.h>
+#include <moveit_msgs/GetPlanningScene.h>
+#include <moveit_msgs/PlanningScene.h>
 
 namespace descartes_moveit
 {
@@ -30,6 +32,16 @@ public:
   virtual bool getFK(const std::vector<double>& joint_pose, Eigen::Affine3d& pose) const;
 
   virtual bool isValid(const std::vector<double>& joint_pose) const;
+
+  virtual bool updatePlanningScene(const moveit_msgs::PlanningScene &scene);
+
+  /**
+   * @brief Returns the underlying moveit state object so it can be used to generate seeds
+   */
+  moveit::core::RobotStatePtr getState()
+  {
+    return robot_state_;
+  }
 
   /**
    * @brief Sets the internal state of the robot model to the argument. For the IKFast impl,

--- a/descartes_moveit/include/descartes_moveit/jaco3_moveit_state_adapter.h
+++ b/descartes_moveit/include/descartes_moveit/jaco3_moveit_state_adapter.h
@@ -63,9 +63,9 @@ protected:
 
   collision_detection::AllowedCollisionMatrix acm_;
   collision_detection::CollisionRequest collision_request_;
-  std::string octomap_name_ = "<octomap>";
-  std::vector<std::string> check_collision_links_ = {"forearm_link", "half_arm_1_link", "spherical_wrist_2_link"};
-
+  std::string octomap_link_ = "<octomap>";
+  std::vector<std::string> collision_arm_links_ = {"forearm_link", "half_arm_1_link", "spherical_wrist_2_link"};
+  std::vector<std::string> collision_robot_links_ = {"tower_link", "arm_base_cover", "camera_box", "mobile_base_link"};
 };
 
 }  // end namespace 'descartes_moveit'

--- a/descartes_moveit/include/descartes_moveit/jaco3_moveit_state_adapter.h
+++ b/descartes_moveit/include/descartes_moveit/jaco3_moveit_state_adapter.h
@@ -45,8 +45,8 @@ public:
   
 protected:
   bool computeJaco3Transforms();
-  bool isInCollision(const std::vector<double>& joint_pose) const;
-  
+  virtual bool isInCollision(const std::vector<double>& joint_pose) const;
+
   /**
    * The IKFast implementation commonly solves between 'base_link' of a robot
    * and 'tool0'. We will commonly want to take advantage of an additional

--- a/descartes_moveit/include/descartes_moveit/jaco3_moveit_state_adapter.h
+++ b/descartes_moveit/include/descartes_moveit/jaco3_moveit_state_adapter.h
@@ -45,7 +45,8 @@ public:
   
 protected:
   bool computeJaco3Transforms();
-
+  bool isInCollision(const std::vector<double>& joint_pose) const;
+  
   /**
    * The IKFast implementation commonly solves between 'base_link' of a robot
    * and 'tool0'. We will commonly want to take advantage of an additional

--- a/descartes_moveit/include/descartes_moveit/moveit_state_adapter.h
+++ b/descartes_moveit/include/descartes_moveit/moveit_state_adapter.h
@@ -110,7 +110,7 @@ protected:
    * called previously in order to enable collision checks, otherwise it will return false.
    * @param joint_pose the joint values at which check for collisions will be made
    */
-  bool isInCollision(const std::vector<double>& joint_pose) const;
+  virtual bool isInCollision(const std::vector<double>& joint_pose) const;
 
   /**
    * @brief Checks to see if the given joint_pose state is inside the bounds for the initialized

--- a/descartes_moveit/package.xml
+++ b/descartes_moveit/package.xml
@@ -23,6 +23,7 @@
   <depend>moveit_ros_planning</depend>
   <depend>pluginlib</depend>
   <depend>peanut_kinematics</depend>
+  <depend>moveit_msgs</depend>
   <build_depend>eigen</build_depend>
 
   <export>

--- a/descartes_moveit/src/jaco3_moveit_state_adapter.cpp
+++ b/descartes_moveit/src/jaco3_moveit_state_adapter.cpp
@@ -201,6 +201,7 @@ bool descartes_moveit::Jaco3MoveitStateAdapter::isValid(const std::vector<double
 bool descartes_moveit::Jaco3MoveitStateAdapter::updatePlanningScene(const moveit_msgs::PlanningScene &scene){
     ROS_INFO("Updating descrates planning scene");
     planning_scene_->setPlanningSceneMsg(scene);
+    acm_ = planning_scene_->getAllowedCollisionMatrix();
 }
 
 bool descartes_moveit::Jaco3MoveitStateAdapter::isInCollision(const std::vector<double>& joint_pose) const
@@ -208,18 +209,16 @@ bool descartes_moveit::Jaco3MoveitStateAdapter::isInCollision(const std::vector<
   bool in_collision = false;
   collision_detection::CollisionRequest collision_request;
   collision_detection::CollisionResult collision_result;
-  collision_detection::AllowedCollisionMatrix acm;
 
   if (check_collisions_)
   { 
     moveit::core::RobotState state = planning_scene_->getCurrentStateNonConst();
     state.setJointGroupPositions(joint_group_, joint_pose);
     
-    acm = planning_scene_->getAllowedCollisionMatrix();
     //collision_request.group_name = group_name_;
     collision_request.contacts = true;
 
-    planning_scene_->checkCollision(collision_request, collision_result, state, acm);
+    planning_scene_->checkCollision(collision_request, collision_result, state, acm_);
     in_collision = collision_result.collision;
   }
   

--- a/descartes_moveit/src/jaco3_moveit_state_adapter.cpp
+++ b/descartes_moveit/src/jaco3_moveit_state_adapter.cpp
@@ -199,15 +199,15 @@ bool descartes_moveit::Jaco3MoveitStateAdapter::isValid(const std::vector<double
 }
 
 bool descartes_moveit::Jaco3MoveitStateAdapter::updatePlanningScene(const moveit_msgs::PlanningScene &scene){
+    // Initialize planning scene
     ROS_INFO("Updating descrates planning scene");
     planning_scene_->setPlanningSceneMsg(scene);
+    
+    // Update ACM
     acm_ = planning_scene_->getAllowedCollisionMatrix();
-
-    // Initialize planning scene
-    std::string octomap_name = "<octomap>";
-    std::vector<std::string> check_collision_links = {"shoulder_link", "half_arm_1_link", "half_arm_2_link", "forearm_link", "end_effector_link"};
     acm_.setEntry(true);
-    acm_.setEntry(octomap_name, check_collision_links, false);
+    acm_.setEntry(octomap_name_, check_collision_links_, false);
+    collision_request_.contacts = true;
 }
 
 bool descartes_moveit::Jaco3MoveitStateAdapter::isInCollision(const std::vector<double>& joint_pose) const
@@ -216,16 +216,12 @@ bool descartes_moveit::Jaco3MoveitStateAdapter::isInCollision(const std::vector<
 
   if (check_collisions_)
   {
-    collision_detection::CollisionRequest collision_request;
     collision_detection::CollisionResult collision_result; 
     
     moveit::core::RobotState state = planning_scene_->getCurrentStateNonConst();
     state.setJointGroupPositions(joint_group_, joint_pose);
-    
-    //collision_request.group_name = group_name_;
-    collision_request.contacts = true;
 
-    planning_scene_->checkCollision(collision_request, collision_result, state, acm_);
+    planning_scene_->checkCollision(collision_request_, collision_result, state, acm_);
     in_collision = collision_result.collision;
 
     if (in_collision){

--- a/descartes_moveit/src/jaco3_moveit_state_adapter.cpp
+++ b/descartes_moveit/src/jaco3_moveit_state_adapter.cpp
@@ -202,6 +202,12 @@ bool descartes_moveit::Jaco3MoveitStateAdapter::updatePlanningScene(const moveit
     ROS_INFO("Updating descrates planning scene");
     planning_scene_->setPlanningSceneMsg(scene);
     acm_ = planning_scene_->getAllowedCollisionMatrix();
+
+    // Initialize planning scene
+    std::string octomap_name = "<octomap>";
+    std::vector<std::string> check_collision_links = {"shoulder_link", "half_arm_1_link", "half_arm_2_link", "forearm_link", "end_effector_link"};
+    acm_.setEntry(true);
+    acm_.setEntry(octomap_name, check_collision_links, false);
 }
 
 bool descartes_moveit::Jaco3MoveitStateAdapter::isInCollision(const std::vector<double>& joint_pose) const

--- a/descartes_moveit/src/jaco3_moveit_state_adapter.cpp
+++ b/descartes_moveit/src/jaco3_moveit_state_adapter.cpp
@@ -199,5 +199,6 @@ bool descartes_moveit::Jaco3MoveitStateAdapter::isValid(const std::vector<double
 }
 
 bool descartes_moveit::Jaco3MoveitStateAdapter::updatePlanningScene(const moveit_msgs::PlanningScene &scene){
+    ROS_INFO("Updating descrates planning scene");
     planning_scene_->setPlanningSceneMsg(scene);
 }

--- a/descartes_moveit/src/jaco3_moveit_state_adapter.cpp
+++ b/descartes_moveit/src/jaco3_moveit_state_adapter.cpp
@@ -207,11 +207,12 @@ bool descartes_moveit::Jaco3MoveitStateAdapter::updatePlanningScene(const moveit
 bool descartes_moveit::Jaco3MoveitStateAdapter::isInCollision(const std::vector<double>& joint_pose) const
 {
   bool in_collision = false;
-  collision_detection::CollisionRequest collision_request;
-  collision_detection::CollisionResult collision_result;
 
   if (check_collisions_)
-  { 
+  {
+    collision_detection::CollisionRequest collision_request;
+    collision_detection::CollisionResult collision_result; 
+    
     moveit::core::RobotState state = planning_scene_->getCurrentStateNonConst();
     state.setJointGroupPositions(joint_group_, joint_pose);
     
@@ -220,14 +221,16 @@ bool descartes_moveit::Jaco3MoveitStateAdapter::isInCollision(const std::vector<
 
     planning_scene_->checkCollision(collision_request, collision_result, state, acm_);
     in_collision = collision_result.collision;
+
+    if (in_collision){
+      collision_detection::CollisionResult::ContactMap::const_iterator it;
+      for ( it = collision_result.contacts.begin(); it != collision_result.contacts.end(); it++ )
+      {
+        ROS_DEBUG("Contact between: %s and %s", it->first.first.c_str(), it->first.second.c_str());
+      }
+    }
+
   }
   
-  if (in_collision){
-    collision_detection::CollisionResult::ContactMap::const_iterator it;
-    for ( it = collision_result.contacts.begin(); it != collision_result.contacts.end(); it++ )
-    {
-        ROS_DEBUG("Contact between: %s and %s", it->first.first.c_str(), it->first.second.c_str());
-    }
-  }
   return in_collision;
 }

--- a/descartes_moveit/src/jaco3_moveit_state_adapter.cpp
+++ b/descartes_moveit/src/jaco3_moveit_state_adapter.cpp
@@ -197,3 +197,7 @@ bool descartes_moveit::Jaco3MoveitStateAdapter::hasNaN(const std::vector<double>
 bool descartes_moveit::Jaco3MoveitStateAdapter::isValid(const std::vector<double>& joint_pose) const{
   return !hasNaN(joint_pose) && descartes_moveit::MoveitStateAdapter::isValid(joint_pose);
 }
+
+bool descartes_moveit::Jaco3MoveitStateAdapter::updatePlanningScene(const moveit_msgs::PlanningScene &scene){
+    planning_scene_->setPlanningSceneMsg(scene);
+}

--- a/descartes_moveit/src/jaco3_moveit_state_adapter.cpp
+++ b/descartes_moveit/src/jaco3_moveit_state_adapter.cpp
@@ -205,8 +205,15 @@ bool descartes_moveit::Jaco3MoveitStateAdapter::updatePlanningScene(const moveit
     
     // Update ACM
     acm_ = planning_scene_->getAllowedCollisionMatrix();
+    // Disable all collision checking
     acm_.setEntry(true);
-    acm_.setEntry(octomap_name_, check_collision_links_, false);
+    // Collision check selected arm links with octomap
+    acm_.setEntry(octomap_link_, collision_arm_links_, false);
+    // Collision check selected arm links with selected robot links
+    acm_.setEntry(collision_robot_links_, collision_arm_links_, false);
+
+    // Initialize collision request message. 
+    // Setting this to false could descrease collision checking speed
     collision_request_.contacts = true;
 }
 
@@ -228,7 +235,7 @@ bool descartes_moveit::Jaco3MoveitStateAdapter::isInCollision(const std::vector<
       collision_detection::CollisionResult::ContactMap::const_iterator it;
       for ( it = collision_result.contacts.begin(); it != collision_result.contacts.end(); it++ )
       {
-        ROS_DEBUG("Contact between: %s and %s", it->first.first.c_str(), it->first.second.c_str());
+        ROS_ERROR("Contact between: %s and %s", it->first.first.c_str(), it->first.second.c_str());
       }
     }
 

--- a/descartes_moveit/src/jaco3_moveit_state_adapter.cpp
+++ b/descartes_moveit/src/jaco3_moveit_state_adapter.cpp
@@ -207,8 +207,6 @@ bool descartes_moveit::Jaco3MoveitStateAdapter::updatePlanningScene(const moveit
     acm_ = planning_scene_->getAllowedCollisionMatrix();
     // Disable all collision checking
     acm_.setEntry(true);
-    // Collision check selected arm links with octomap
-    acm_.setEntry(octomap_link_, collision_arm_links_, false);
     // Collision check selected arm links with selected robot links
     acm_.setEntry(collision_robot_links_, collision_arm_links_, false);
 

--- a/descartes_moveit/src/moveit_state_adapter.cpp
+++ b/descartes_moveit/src/moveit_state_adapter.cpp
@@ -244,29 +244,12 @@ bool MoveitStateAdapter::getAllIK(const Eigen::Affine3d& pose, std::vector<std::
 bool MoveitStateAdapter::isInCollision(const std::vector<double>& joint_pose) const
 {
   bool in_collision = false;
-  collision_detection::CollisionRequest collision_request;
-  collision_detection::CollisionResult collision_result;
-  collision_detection::AllowedCollisionMatrix acm;
-
   if (check_collisions_)
-  { 
-    moveit::core::RobotState state = planning_scene_->getCurrentStateNonConst();
+  {
+    moveit::core::RobotState state (robot_model_ptr_);
+    state.setToDefaultValues();
     state.setJointGroupPositions(joint_group_, joint_pose);
-    
-    acm = planning_scene_->getAllowedCollisionMatrix();
-    //collision_request.group_name = group_name_;
-    collision_request.contacts = true;
-
-    planning_scene_->checkCollision(collision_request, collision_result, state, acm);
-    in_collision = collision_result.collision;
-  }
-  
-  if (in_collision){
-    collision_detection::CollisionResult::ContactMap::const_iterator it;
-    for ( it = collision_result.contacts.begin(); it != collision_result.contacts.end(); it++ )
-    {
-        ROS_DEBUG("Contact between: %s and %s", it->first.first.c_str(), it->first.second.c_str());
-    }
+    in_collision = planning_scene_->isStateColliding(state, group_name_);
   }
   return in_collision;
 }

--- a/descartes_moveit/src/moveit_state_adapter.cpp
+++ b/descartes_moveit/src/moveit_state_adapter.cpp
@@ -244,12 +244,29 @@ bool MoveitStateAdapter::getAllIK(const Eigen::Affine3d& pose, std::vector<std::
 bool MoveitStateAdapter::isInCollision(const std::vector<double>& joint_pose) const
 {
   bool in_collision = false;
+  collision_detection::CollisionRequest collision_request;
+  collision_detection::CollisionResult collision_result;
+  collision_detection::AllowedCollisionMatrix acm;
+
   if (check_collisions_)
-  {
-    moveit::core::RobotState state (robot_model_ptr_);
-    state.setToDefaultValues();
+  { 
+    moveit::core::RobotState state = planning_scene_->getCurrentStateNonConst();
     state.setJointGroupPositions(joint_group_, joint_pose);
-    in_collision = planning_scene_->isStateColliding(state, group_name_);
+    
+    acm = planning_scene_->getAllowedCollisionMatrix();
+    //collision_request.group_name = group_name_;
+    collision_request.contacts = true;
+
+    planning_scene_->checkCollision(collision_request, collision_result, state, acm);
+    in_collision = collision_result.collision;
+  }
+  
+  if (in_collision){
+    collision_detection::CollisionResult::ContactMap::const_iterator it;
+    for ( it = collision_result.contacts.begin(); it != collision_result.contacts.end(); it++ )
+    {
+        ROS_DEBUG("Contact between: %s and %s", it->first.first.c_str(), it->first.second.c_str());
+    }
   }
   return in_collision;
 }


### PR DESCRIPTION
Add collision checking functionality
 - Add a function to update the planning scene that descartes uses to collision with. The default one it loads is not correct

Note: Leaving `octomap_link_` in there in case it needs to be used in the future