### PR TITLE
Get planning scene through planning scene monitor

### DIFF
--- a/descartes_core/include/descartes_core/robot_model.h
+++ b/descartes_core/include/descartes_core/robot_model.h
@@ -147,7 +147,7 @@ public:
 
   virtual bool isValidMove(const double* s, const double* f, double dt) const = 0;
 
-  virtual bool updatePlanningScene(const planning_scene_monitor::LockedPlanningSceneRO ps){
+  virtual bool updatePlanningScene(planning_scene::PlanningScenePtr ps){
     ROS_ERROR("updatePlanningScene() method not implemented");
     return false;
   }

--- a/descartes_core/include/descartes_core/robot_model.h
+++ b/descartes_core/include/descartes_core/robot_model.h
@@ -23,6 +23,7 @@
 #include <moveit/kinematic_constraints/kinematic_constraint.h>
 #include "descartes_core/utils.h"
 #include <moveit_msgs/PlanningScene.h>
+#include <moveit/planning_scene_monitor/planning_scene_monitor.h>
 
 namespace descartes_core
 {
@@ -146,7 +147,7 @@ public:
 
   virtual bool isValidMove(const double* s, const double* f, double dt) const = 0;
 
-  virtual bool updatePlanningScene(){
+  virtual bool updatePlanningScene(const planning_scene_monitor::LockedPlanningSceneRO ps){
     ROS_ERROR("updatePlanningScene() method not implemented");
     return false;
   }

--- a/descartes_core/include/descartes_core/robot_model.h
+++ b/descartes_core/include/descartes_core/robot_model.h
@@ -146,9 +146,7 @@ public:
 
   virtual bool isValidMove(const double* s, const double* f, double dt) const = 0;
 
-  virtual bool updatePlanningScene(const moveit_msgs::PlanningScene &scene){
-    // Add unused parameters so compiler does not complain about unused parameters
-    (void)scene;
+  virtual bool updatePlanningScene(){
     ROS_ERROR("updatePlanningScene() method not implemented");
     return false;
   }

--- a/descartes_moveit/include/descartes_moveit/jaco3_moveit_state_adapter.h
+++ b/descartes_moveit/include/descartes_moveit/jaco3_moveit_state_adapter.h
@@ -33,7 +33,7 @@ public:
 
   virtual bool isValid(const std::vector<double>& joint_pose) const;
 
-  virtual bool updatePlanningScene();
+  virtual bool updatePlanningScene(const planning_scene_monitor::LockedPlanningSceneRO ps);
 
   /**
    * @brief Sets the internal state of the robot model to the argument. For the IKFast impl,

--- a/descartes_moveit/include/descartes_moveit/jaco3_moveit_state_adapter.h
+++ b/descartes_moveit/include/descartes_moveit/jaco3_moveit_state_adapter.h
@@ -73,7 +73,6 @@ protected:
   std::string octomap_link_ = "<octomap>";
   std::vector<std::string> collision_arm_links_ = {"half_arm_2_link", "forearm_link"};
   std::vector<std::string> collision_robot_links_ = {"tower_link", "camera_box"};
-  std::vector<std::string> collision_octomap_links_ = {"sprayer"};
 };
 
 }  // end namespace 'descartes_moveit'

--- a/descartes_moveit/include/descartes_moveit/jaco3_moveit_state_adapter.h
+++ b/descartes_moveit/include/descartes_moveit/jaco3_moveit_state_adapter.h
@@ -33,7 +33,7 @@ public:
 
   virtual bool isValid(const std::vector<double>& joint_pose) const;
 
-  virtual bool updatePlanningScene(const planning_scene_monitor::LockedPlanningSceneRO ps);
+  virtual bool updatePlanningScene(planning_scene::PlanningScenePtr ps);
 
   /**
    * @brief Sets the internal state of the robot model to the argument. For the IKFast impl,
@@ -73,6 +73,7 @@ protected:
   std::string octomap_link_ = "<octomap>";
   std::vector<std::string> collision_arm_links_ = {"half_arm_2_link", "forearm_link"};
   std::vector<std::string> collision_robot_links_ = {"tower_link", "camera_box"};
+  std::vector<std::string> collision_octomap_links_ = {"sprayer"};
 };
 
 }  // end namespace 'descartes_moveit'

--- a/descartes_moveit/include/descartes_moveit/jaco3_moveit_state_adapter.h
+++ b/descartes_moveit/include/descartes_moveit/jaco3_moveit_state_adapter.h
@@ -8,6 +8,7 @@
 #include "descartes_moveit/moveit_state_adapter.h"
 #include <peanut_kinematics/jaco3_ik.h>
 #include <moveit_msgs/PlanningScene.h>
+#include <moveit/planning_scene_monitor/planning_scene_monitor.h>
 
 namespace descartes_moveit
 {
@@ -32,7 +33,7 @@ public:
 
   virtual bool isValid(const std::vector<double>& joint_pose) const;
 
-  virtual bool updatePlanningScene(const moveit_msgs::PlanningScene &scene);
+  virtual bool updatePlanningScene();
 
   /**
    * @brief Sets the internal state of the robot model to the argument. For the IKFast impl,

--- a/descartes_moveit/src/jaco3_moveit_state_adapter.cpp
+++ b/descartes_moveit/src/jaco3_moveit_state_adapter.cpp
@@ -215,10 +215,9 @@ bool descartes_moveit::Jaco3MoveitStateAdapter::isValid(const std::vector<double
   return !hasNaN(joint_pose) && descartes_moveit::MoveitStateAdapter::isValid(joint_pose);
 }
 
-bool descartes_moveit::Jaco3MoveitStateAdapter::updatePlanningScene(const planning_scene_monitor::LockedPlanningSceneRO ps){
+bool descartes_moveit::Jaco3MoveitStateAdapter::updatePlanningScene(planning_scene::PlanningScenePtr ps){
   // Initialize planning scene
-  planning_scene_ = ps->diff();
-  planning_scene_->decoupleParent();
+  planning_scene_ = ps;
   
   // Update ACM
   acm_ = planning_scene_->getAllowedCollisionMatrix();
@@ -226,7 +225,7 @@ bool descartes_moveit::Jaco3MoveitStateAdapter::updatePlanningScene(const planni
   acm_.setEntry(true);
   // Collision check selected arm links with selected robot links
   acm_.setEntry(collision_robot_links_, collision_arm_links_, false);
-  
+
   // Initialize collision request message. 
   // Setting this to false could descrease collision checking speed
   collision_request_.contacts = true;

--- a/descartes_moveit/src/jaco3_moveit_state_adapter.cpp
+++ b/descartes_moveit/src/jaco3_moveit_state_adapter.cpp
@@ -215,12 +215,8 @@ bool descartes_moveit::Jaco3MoveitStateAdapter::isValid(const std::vector<double
   return !hasNaN(joint_pose) && descartes_moveit::MoveitStateAdapter::isValid(joint_pose);
 }
 
-bool descartes_moveit::Jaco3MoveitStateAdapter::updatePlanningScene(){
+bool descartes_moveit::Jaco3MoveitStateAdapter::updatePlanningScene(const planning_scene_monitor::LockedPlanningSceneRO ps){
   // Initialize planning scene
-  ROS_INFO("Updating descartes planning scene");
-  planning_scene_monitor::PlanningSceneMonitorPtr planning_scene_monitor_ptr = std::make_shared<planning_scene_monitor::PlanningSceneMonitor>("robot_description");
-  planning_scene_monitor_ptr->requestPlanningSceneState();
-  planning_scene_monitor::LockedPlanningSceneRO ps(planning_scene_monitor_ptr);
   planning_scene_ = ps->diff();
   planning_scene_->decoupleParent();
   


### PR DESCRIPTION
With the new method of attaching and detaching tools, getting the planning scene through the `/get_plannning_scene` service did not work for collision checking the tools with other links. Collision detection for descartes works if the planning scene is received through the method below. It's also cleaner this way.

# Dependency
This needs to go in the same time as https://github.com/peanut-robotics/peanut_motion_planning/pull/58